### PR TITLE
Fix resource cache locking and material handling

### DIFF
--- a/my_unreal_dx12/Texture.cpp
+++ b/my_unreal_dx12/Texture.cpp
@@ -1,6 +1,7 @@
-﻿#include "Texture.h"
+#include "Texture.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
+#include <stdexcept>
 
 void Texture::LoadFromFile(GraphicsDevice& gd, const char* path)
 {


### PR DESCRIPTION
## Summary
- prevent ResourceCache from holding its mutex during OBJ loading and texture creation and ensure cached assets are reused safely
- correct material processing when parsing OBJ/MTL files so colors apply only to the relevant faces and cache textures per material
- add fence event lifetime management and error handling, plus include the missing <stdexcept> header for texture loading

## Testing
- Not run (Windows-specific build environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910f36763c88328b406275ab342fd71)