### PR TITLE
Refactor ConstantBuffer and Shader Logic

### DIFF
--- a/my_unreal_dx12/ConstantBuffer.h
+++ b/my_unreal_dx12/ConstantBuffer.h
@@ -5,36 +5,56 @@
 #include <DirectXMath.h>
 #include "Utils.h"
 #include <memory>
+#include <cstring>
+
+struct SceneCB
+{
+    DirectX::XMFLOAT4X4 uModel;
+    DirectX::XMFLOAT4X4 uViewProj;
+    DirectX::XMFLOAT4X4 uNormalMatrix;
+};
+static_assert(sizeof(SceneCB) % 16 == 0, "SceneCB must be 16-byte aligned");
 
 class ConstantBuffer
 {
 public:
-	void Create(ID3D12Device* device, UINT sliceCount)
-	{
-		m_sliceSize = Align256(sizeof(DirectX::XMFLOAT4X4));
-		m_totalSize = m_sliceSize * sliceCount;
+    void Create(ID3D12Device* device, UINT sliceCount)
+    {
+        m_sliceSize = Align256(sizeof(SceneCB));
+        m_totalSize = m_sliceSize * sliceCount;
 
+        D3D12_HEAP_PROPERTIES heap{};
+        heap.Type = D3D12_HEAP_TYPE_UPLOAD;
 
-		D3D12_HEAP_PROPERTIES heap{}; heap.Type = D3D12_HEAP_TYPE_UPLOAD;
-		D3D12_RESOURCE_DESC buf{}; buf.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER; buf.Width = m_totalSize; buf.Height = 1; buf.DepthOrArraySize = 1; buf.MipLevels = 1; buf.SampleDesc = { 1,0 }; buf.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-		DXThrow(device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &buf, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&m_resource)));
+        D3D12_RESOURCE_DESC buf{};
+        buf.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        buf.Width = m_totalSize;
+        buf.Height = 1;
+        buf.DepthOrArraySize = 1;
+        buf.MipLevels = 1;
+        buf.SampleDesc = { 1, 0 };
+        buf.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 
+        DXThrow(device->CreateCommittedResource(
+            &heap, D3D12_HEAP_FLAG_NONE,
+            &buf, D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr, IID_PPV_ARGS(&m_resource)));
 
-		D3D12_RANGE r{ 0,0 }; DXThrow(m_resource->Map(0, &r, reinterpret_cast<void**>(&m_mapped)));
-	}
+        D3D12_RANGE r{ 0, 0 };
+        DXThrow(m_resource->Map(0, &r, reinterpret_cast<void**>(&m_mapped)));
+    }
 
+    D3D12_GPU_VIRTUAL_ADDRESS UploadSlice(UINT sliceIndex, const SceneCB& data)
+    {
+        std::memcpy(m_mapped + sliceIndex * m_sliceSize, &data, sizeof(data));
+        return m_resource->GetGPUVirtualAddress() + sliceIndex * m_sliceSize;
+    }
 
-	D3D12_GPU_VIRTUAL_ADDRESS UploadSlice(UINT sliceIndex, const DirectX::XMFLOAT4X4& data)
-	{
-		std::memcpy(m_mapped + sliceIndex * m_sliceSize, &data, sizeof(data));
-		return m_resource->GetGPUVirtualAddress() + sliceIndex * m_sliceSize;
-	}
-
-
-	UINT SliceSize() const { return m_sliceSize; }
-
+    UINT SliceSize() const { return m_sliceSize; }
 
 private:
-	Microsoft::WRL::ComPtr<ID3D12Resource> m_resource;
-	UINT m_sliceSize = 0; UINT m_totalSize = 0; uint8_t* m_mapped = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_resource;
+    UINT m_sliceSize = 0;
+    UINT m_totalSize = 0;
+    uint8_t* m_mapped = nullptr;
 };

--- a/my_unreal_dx12/Shaders.h
+++ b/my_unreal_dx12/Shaders.h
@@ -1,6 +1,11 @@
 ﻿#pragma once
 static const char* kVertexShaderSrc = R"(
-cbuffer Scene : register(b0) { float4x4 uMVP; }
+cbuffer Scene : register(b0)
+{
+    float4x4 uModel;
+    float4x4 uViewProj;
+    float4x4 uNormalMatrix;
+}
 
 struct VSIn {
     float3 pos : POSITION;
@@ -18,8 +23,12 @@ struct VSOut {
 VSOut main(VSIn v)
 {
     VSOut o;
-    o.pos = mul(float4(v.pos,1), uMVP);
-    o.nrm = normalize(v.nrm);
+    float4 wpos = mul(float4(v.pos, 1.0), uModel);
+    o.pos = mul(wpos, uViewProj);
+
+    float3x3 Nmat = (float3x3)uNormalMatrix;
+    o.nrm = normalize(mul(v.nrm, Nmat));
+
     o.col = v.col;
     o.uv  = v.uv;
     return o;
@@ -30,14 +39,14 @@ static const char* kPixelShaderSrc = R"(
 Texture2D    uTexture : register(t0);
 SamplerState uSampler : register(s0);
 
-static const float3 kLightDir   = normalize(float3(1.0, -1.0, 0.0));
+static const float3 kLightDir   = normalize(float3(0.0, 1.0, 0.0));
 static const float3 kLightColor = float3(1.0, 0.98, 0.90);
-static const float3 kAmbient    = float3(0.2f, 0.2f, 0.2f);
+static const float3 kAmbient    = float3(0.2, 0.2, 0.2);
 
 float4 main(float4 pos:SV_Position, float3 nrm:NORMAL0, float3 col:COLOR0, float2 uv:TEXCOORD0) : SV_Target
 {
     float3 N = normalize(nrm);
-    float  NdotL = saturate(dot(N, -kLightDir));
+    float  NdotL = saturate(dot(N, kLightDir));
     float3 lit = kAmbient + kLightColor * NdotL;
 
     float3 base = uTexture.Sample(uSampler, uv).rgb * col;

--- a/my_unreal_dx12/WindowDX12.cpp
+++ b/my_unreal_dx12/WindowDX12.cpp
@@ -1,3 +1,1 @@
-// Ensure you declare the type for m_whiteTex before assignment
-// For example, if m_whiteTex is of type Texture, use:
 #include "WindowDX12.h"

--- a/my_unreal_dx12/WindowDX12.h
+++ b/my_unreal_dx12/WindowDX12.h
@@ -149,17 +149,24 @@ public:
         const XMMATRIX M = mesh.Transform();
         const XMMATRIX V = m_camera.View();
         const XMMATRIX P = m_camera.Proj();
+        const XMMATRIX VP = V * P;
 
-        XMFLOAT4X4 mvp;
-        XMStoreFloat4x4(&mvp, XMMatrixTranspose(M * V * P));
+        XMVECTOR det;
+        const XMMATRIX MInv = XMMatrixInverse(&det, M);
+        const XMMATRIX NMat = XMMatrixTranspose(MInv);
+
+        SceneCB cb{};
+        XMStoreFloat4x4(&cb.uModel, XMMatrixTranspose(M));
+        XMStoreFloat4x4(&cb.uViewProj, XMMatrixTranspose(VP));
+        XMStoreFloat4x4(&cb.uNormalMatrix, XMMatrixTranspose(NMat));
 
         const UINT frame = m_swap.FrameIndex();
         const UINT slice = frame * kMaxDrawsPerFrame + (m_drawCursor++);
 
-        auto addr = m_cb.UploadSlice(slice, mvp);
+        auto addr = m_cb.UploadSlice(slice, cb);
 
         m_renderer.DrawMesh(mesh, addr);
-		m_trianglesCount += mesh.IndexCount() / 3;
+        m_trianglesCount += mesh.IndexCount() / 3;
     }
 
     void Display()


### PR DESCRIPTION
Updated `ConstantBuffer.h` to introduce `SceneCB` struct with `uModel`, `uViewProj`, and `uNormalMatrix` matrices, replacing the previous single matrix usage. Modified `Create` and `UploadSlice` methods to accommodate `SceneCB`, ensuring 16-byte alignment.

Expanded `Scene` constant buffer in `Shaders.h` to include new matrices, updating vertex shader logic for position and normal transformations. Adjusted light direction and ambient color in the pixel shader.

Removed unnecessary comment in `WindowDX12.cpp`. Replaced `mvp` calculation in `WindowDX12.h` with `SceneCB` structure, updating `UploadSlice` to use `SceneCB`.